### PR TITLE
Added FizzyUtils to dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This plugin is built using BSIPA4 so you need that, as well as
  * [SiraUtil](https://github.com/Auros/SiraUtil)
  * [BeatSaberMarkupLanguage](https://github.com/monkeymanboy/BeatSaberMarkupLanguage)
  * [DiscordCore](https://github.com/FizzyApple12/DiscordCore)
+ * [FizzyUtils](https://github.com/FizzyApple12/FizzyUtils)
 
 <br/>
 


### PR DESCRIPTION
So uhh I spent a whole week wondering why I couldn't get this mod to work after I did a fresh reinstall of my primary mods. Turns out I also needed to copy the FizzyUtils dll. The people over at the discord group were nice enough to point out that this is mentioned in the Discord release channel, but it might also need to be here in the github readme in case someone else scratches their head for a week like I did.